### PR TITLE
feat(api): Add matching endpoint to score jobs against stored profile

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,8 @@ import { ApprovalsController } from "./approvals/approvals.controller";
 import { ApprovalsService } from "./approvals/approvals.service";
 import { JobsController } from "./jobs/jobs.controller";
 import { JobsService } from "./jobs/jobs.service";
+import { ProfileController } from "./profile/profile.controller";
+import { ProfileService } from "./profile/profile.service";
 
 @Module({
   controllers: [
@@ -20,9 +22,10 @@ import { JobsService } from "./jobs/jobs.service";
     ArtefactsController,
     MatchingController,
     ApprovalsController,
-    JobsController
+    JobsController,
+    ProfileController
   ],
-  providers: [AuthGuard, ArtefactsService, MatchingService, ApprovalsService, JobsService]
+  providers: [AuthGuard, ArtefactsService, MatchingService, ApprovalsService, JobsService, ProfileService]
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/apps/api/src/matching/matching.controller.ts
+++ b/apps/api/src/matching/matching.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Post } from "@nestjs/common";
+import { Body, Controller, Get, Param, Post, Req } from "@nestjs/common";
+import { Request } from "express";
 
 import { MatchJob, MatchProfile } from "@cv/matching";
 import { MatchingService } from "./matching.service";
@@ -27,5 +28,11 @@ export class MatchingController {
     };
 
     return this.matchingService.score(body.profile, job);
+  }
+
+  @Get("jobs/:jobId")
+  getJobMatch(@Req() request: Request, @Param("jobId") jobId: string) {
+    const tenantId = request.tenantId!;
+    return this.matchingService.getJobMatch(tenantId, jobId);
   }
 }

--- a/apps/api/src/matching/matching.service.ts
+++ b/apps/api/src/matching/matching.service.ts
@@ -1,10 +1,65 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { prisma } from "@cv/db";
 
-import { MatchJob, MatchProfile, matchJob } from "@cv/matching";
+import { MatchJob, MatchProfile, MatchResult, matchJob } from "@cv/matching";
+
+export interface JobMatchResult extends MatchResult {
+  job: {
+    id: string;
+    title: string;
+  };
+}
 
 @Injectable()
 export class MatchingService {
-  score(profile: MatchProfile, job: MatchJob) {
+  score(profile: MatchProfile, job: MatchJob): MatchResult {
     return matchJob(profile, job);
+  }
+
+  async getJobMatch(tenantId: string, jobId: string): Promise<JobMatchResult> {
+    // Fetch job by ID
+    const job = await prisma.job.findFirst({
+      where: { id: jobId, tenantId }
+    });
+
+    if (!job) {
+      throw new NotFoundException("Job not found");
+    }
+
+    // Fetch tenant's profile
+    const profile = await prisma.userProfile.findUnique({
+      where: { tenantId }
+    });
+
+    if (!profile) {
+      throw new BadRequestException("Profile not configured. Create a profile first via PUT /profile");
+    }
+
+    // Build MatchProfile from stored profile
+    const matchProfile: MatchProfile = {
+      desiredRoles: profile.desiredRoles,
+      seniority: profile.seniority as "junior" | "mid" | "senior",
+      location: profile.location,
+      mustHaveSkills: profile.mustHaveSkills
+    };
+
+    // Build MatchJob from stored job
+    const matchJobData: MatchJob = {
+      title: job.title,
+      description: job.description,
+      location: job.location ?? undefined,
+      postedAt: job.postedAt ?? undefined
+    };
+
+    // Compute match score
+    const result = matchJob(matchProfile, matchJobData);
+
+    return {
+      ...result,
+      job: {
+        id: job.id,
+        title: job.title
+      }
+    };
   }
 }

--- a/apps/api/src/profile/profile.controller.ts
+++ b/apps/api/src/profile/profile.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Get, NotFoundException, Put, Req } from "@nestjs/common";
+import { Request } from "express";
+
+import { ProfileService } from "./profile.service";
+import { UpsertProfileDto } from "./profile.dto";
+
+@Controller("profile")
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  @Get()
+  async getProfile(@Req() request: Request) {
+    const tenantId = request.tenantId!;
+    const profile = await this.profileService.getProfile(tenantId);
+
+    if (!profile) {
+      throw new NotFoundException("Profile not configured");
+    }
+
+    return profile;
+  }
+
+  @Put()
+  async upsertProfile(@Req() request: Request, @Body() dto: UpsertProfileDto) {
+    const tenantId = request.tenantId!;
+    return this.profileService.upsertProfile(tenantId, dto);
+  }
+}

--- a/apps/api/src/profile/profile.dto.ts
+++ b/apps/api/src/profile/profile.dto.ts
@@ -6,6 +6,7 @@ export class UpsertProfileDto {
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })
+  @IsNotEmpty({ each: true })
   desiredRoles!: string[];
 
   @IsString()
@@ -20,6 +21,7 @@ export class UpsertProfileDto {
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })
+  @IsNotEmpty({ each: true })
   mustHaveSkills!: string[];
 }
 

--- a/apps/api/src/profile/profile.dto.ts
+++ b/apps/api/src/profile/profile.dto.ts
@@ -1,0 +1,34 @@
+import { ArrayNotEmpty, IsArray, IsIn, IsNotEmpty, IsString } from "class-validator";
+
+export type Seniority = "junior" | "mid" | "senior";
+
+export class UpsertProfileDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  desiredRoles!: string[];
+
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(["junior", "mid", "senior"])
+  seniority!: Seniority;
+
+  @IsString()
+  @IsNotEmpty()
+  location!: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  mustHaveSkills!: string[];
+}
+
+export interface ProfileResponseDto {
+  id: string;
+  desiredRoles: string[];
+  seniority: Seniority;
+  location: string;
+  mustHaveSkills: string[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/apps/api/src/profile/profile.service.ts
+++ b/apps/api/src/profile/profile.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from "@nestjs/common";
+import { prisma } from "@cv/db";
+
+import { ProfileResponseDto, Seniority, UpsertProfileDto } from "./profile.dto";
+
+@Injectable()
+export class ProfileService {
+  async getProfile(tenantId: string): Promise<ProfileResponseDto | null> {
+    const profile = await prisma.userProfile.findUnique({
+      where: { tenantId }
+    });
+
+    if (!profile) {
+      return null;
+    }
+
+    return {
+      id: profile.id,
+      desiredRoles: profile.desiredRoles,
+      seniority: profile.seniority as Seniority,
+      location: profile.location,
+      mustHaveSkills: profile.mustHaveSkills,
+      createdAt: profile.createdAt.toISOString(),
+      updatedAt: profile.updatedAt.toISOString()
+    };
+  }
+
+  async upsertProfile(tenantId: string, dto: UpsertProfileDto): Promise<ProfileResponseDto> {
+    const profile = await prisma.userProfile.upsert({
+      where: { tenantId },
+      create: {
+        tenantId,
+        desiredRoles: dto.desiredRoles,
+        seniority: dto.seniority,
+        location: dto.location,
+        mustHaveSkills: dto.mustHaveSkills
+      },
+      update: {
+        desiredRoles: dto.desiredRoles,
+        seniority: dto.seniority,
+        location: dto.location,
+        mustHaveSkills: dto.mustHaveSkills
+      }
+    });
+
+    return {
+      id: profile.id,
+      desiredRoles: profile.desiredRoles,
+      seniority: profile.seniority as Seniority,
+      location: profile.location,
+      mustHaveSkills: profile.mustHaveSkills,
+      createdAt: profile.createdAt.toISOString(),
+      updatedAt: profile.updatedAt.toISOString()
+    };
+  }
+}

--- a/apps/api/test/matching.e2e-spec.ts
+++ b/apps/api/test/matching.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import request from "supertest";
+import { prisma } from "@cv/db";
 
 import { AppModule } from "../src/app.module";
 
@@ -42,5 +43,150 @@ describe("Matching (e2e)", () => {
 
     expect(response.body.score).toBeGreaterThan(0);
     expect(response.body.explanations.length).toBeGreaterThan(0);
+  });
+
+  describe("GET /matching/jobs/:jobId", () => {
+    it("returns match score when profile exists", async () => {
+      const tenant = await prisma.tenant.create({ data: { name: "MatchTenant" } });
+      const source = await prisma.jobSource.create({
+        data: {
+          tenantId: tenant.id,
+          type: "greenhouse",
+          name: "Greenhouse",
+          config: { baseUrl: "https://boards.greenhouse.io" }
+        }
+      });
+
+      const job = await prisma.job.create({
+        data: {
+          tenantId: tenant.id,
+          jobSourceId: source.id,
+          externalId: "match-job-1",
+          title: "Senior Fullstack Developer",
+          description: "Build web applications with TypeScript and React",
+          location: "Remote",
+          url: "https://example.com/job-1",
+          contentHash: "hash-match-1",
+          postedAt: new Date()
+        }
+      });
+
+      await prisma.userProfile.create({
+        data: {
+          tenantId: tenant.id,
+          desiredRoles: ["fullstack", "backend"],
+          seniority: "senior",
+          location: "remote",
+          mustHaveSkills: ["typescript", "react"]
+        }
+      });
+
+      const response = await request(app.getHttpServer())
+        .get(`/matching/jobs/${job.id}`)
+        .set("x-tenant-id", tenant.id)
+        .expect(200);
+
+      expect(response.body.score).toBeGreaterThan(0);
+      expect(response.body.explanations).toContain("role match");
+      expect(response.body.explanations).toContain("seniority match");
+      expect(response.body.explanations).toContain("location match");
+      expect(response.body.explanations).toContain("skills match");
+      expect(response.body.job.id).toBe(job.id);
+      expect(response.body.job.title).toBe("Senior Fullstack Developer");
+    });
+
+    it("returns 400 when no profile configured", async () => {
+      const tenant = await prisma.tenant.create({ data: { name: "NoProfileTenant" } });
+      const source = await prisma.jobSource.create({
+        data: {
+          tenantId: tenant.id,
+          type: "greenhouse",
+          name: "Greenhouse",
+          config: { baseUrl: "https://boards.greenhouse.io" }
+        }
+      });
+
+      const job = await prisma.job.create({
+        data: {
+          tenantId: tenant.id,
+          jobSourceId: source.id,
+          externalId: "match-job-2",
+          title: "Backend Developer",
+          description: "Build APIs",
+          location: "NYC",
+          url: "https://example.com/job-2",
+          contentHash: "hash-match-2"
+        }
+      });
+
+      const response = await request(app.getHttpServer())
+        .get(`/matching/jobs/${job.id}`)
+        .set("x-tenant-id", tenant.id)
+        .expect(400);
+
+      expect(response.body.message).toContain("Profile not configured");
+    });
+
+    it("returns 404 when job not found", async () => {
+      const tenant = await prisma.tenant.create({ data: { name: "JobNotFoundTenant" } });
+
+      await prisma.userProfile.create({
+        data: {
+          tenantId: tenant.id,
+          desiredRoles: ["frontend"],
+          seniority: "mid",
+          location: "remote",
+          mustHaveSkills: ["vue"]
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get("/matching/jobs/nonexistent-job-id")
+        .set("x-tenant-id", tenant.id)
+        .expect(404);
+    });
+
+    it("returns 404 when job belongs to different tenant", async () => {
+      const tenant1 = await prisma.tenant.create({ data: { name: "Tenant1" } });
+      const tenant2 = await prisma.tenant.create({ data: { name: "Tenant2" } });
+
+      const source = await prisma.jobSource.create({
+        data: {
+          tenantId: tenant1.id,
+          type: "greenhouse",
+          name: "Greenhouse",
+          config: { baseUrl: "https://boards.greenhouse.io" }
+        }
+      });
+
+      const job = await prisma.job.create({
+        data: {
+          tenantId: tenant1.id,
+          jobSourceId: source.id,
+          externalId: "match-job-3",
+          title: "DevOps Engineer",
+          description: "Build infrastructure",
+          location: "Remote",
+          url: "https://example.com/job-3",
+          contentHash: "hash-match-3"
+        }
+      });
+
+      await prisma.userProfile.create({
+        data: {
+          tenantId: tenant2.id,
+          desiredRoles: ["devops"],
+          seniority: "senior",
+          location: "remote",
+          mustHaveSkills: ["kubernetes"]
+        }
+      });
+
+      // Try to access tenant1's job with tenant2's credentials
+      await request(app.getHttpServer())
+        .get(`/matching/jobs/${job.id}`)
+        .set("x-tenant-id", tenant2.id)
+        .expect(404);
+    });
   });
 });

--- a/apps/api/test/profile.e2e-spec.ts
+++ b/apps/api/test/profile.e2e-spec.ts
@@ -1,0 +1,161 @@
+import { INestApplication, MiddlewareConsumer, Module, NestModule, ValidationPipe } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { prisma } from "@cv/db";
+
+import { ProfileController } from "../src/profile/profile.controller";
+import { ProfileService } from "../src/profile/profile.service";
+import { TenantMiddleware } from "../src/tenant/tenant.middleware";
+
+@Module({
+  controllers: [ProfileController],
+  providers: [ProfileService]
+})
+class TestModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(TenantMiddleware).forRoutes("*");
+  }
+}
+
+describe("Profile (e2e)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [TestModule]
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("returns 404 when no profile exists", async () => {
+    const tenant = await prisma.tenant.create({ data: { name: "NoProfile" } });
+
+    await request(app.getHttpServer())
+      .get("/profile")
+      .set("x-tenant-id", tenant.id)
+      .expect(404);
+  });
+
+  it("creates profile with PUT", async () => {
+    const tenant = await prisma.tenant.create({ data: { name: "CreateProfile" } });
+
+    const profileData = {
+      desiredRoles: ["fullstack", "backend"],
+      seniority: "mid",
+      location: "remote",
+      mustHaveSkills: ["typescript", "nodejs"]
+    };
+
+    const response = await request(app.getHttpServer())
+      .put("/profile")
+      .set("x-tenant-id", tenant.id)
+      .send(profileData)
+      .expect(200);
+
+    expect(response.body.desiredRoles).toEqual(["fullstack", "backend"]);
+    expect(response.body.seniority).toBe("mid");
+    expect(response.body.location).toBe("remote");
+    expect(response.body.mustHaveSkills).toEqual(["typescript", "nodejs"]);
+    expect(response.body.id).toBeDefined();
+    expect(response.body.createdAt).toBeDefined();
+    expect(response.body.updatedAt).toBeDefined();
+  });
+
+  it("returns profile after creation", async () => {
+    const tenant = await prisma.tenant.create({ data: { name: "GetProfile" } });
+
+    await prisma.userProfile.create({
+      data: {
+        tenantId: tenant.id,
+        desiredRoles: ["frontend"],
+        seniority: "senior",
+        location: "new york",
+        mustHaveSkills: ["react", "css"]
+      }
+    });
+
+    const response = await request(app.getHttpServer())
+      .get("/profile")
+      .set("x-tenant-id", tenant.id)
+      .expect(200);
+
+    expect(response.body.desiredRoles).toEqual(["frontend"]);
+    expect(response.body.seniority).toBe("senior");
+    expect(response.body.location).toBe("new york");
+    expect(response.body.mustHaveSkills).toEqual(["react", "css"]);
+  });
+
+  it("updates existing profile with PUT", async () => {
+    const tenant = await prisma.tenant.create({ data: { name: "UpdateProfile" } });
+
+    await prisma.userProfile.create({
+      data: {
+        tenantId: tenant.id,
+        desiredRoles: ["devops"],
+        seniority: "junior",
+        location: "austin",
+        mustHaveSkills: ["docker"]
+      }
+    });
+
+    const updatedData = {
+      desiredRoles: ["sre", "platform"],
+      seniority: "senior",
+      location: "remote",
+      mustHaveSkills: ["kubernetes", "terraform"]
+    };
+
+    const response = await request(app.getHttpServer())
+      .put("/profile")
+      .set("x-tenant-id", tenant.id)
+      .send(updatedData)
+      .expect(200);
+
+    expect(response.body.desiredRoles).toEqual(["sre", "platform"]);
+    expect(response.body.seniority).toBe("senior");
+    expect(response.body.location).toBe("remote");
+    expect(response.body.mustHaveSkills).toEqual(["kubernetes", "terraform"]);
+  });
+
+  it("validates profile data", async () => {
+    const tenant = await prisma.tenant.create({ data: { name: "ValidateProfile" } });
+
+    // Missing required fields
+    await request(app.getHttpServer())
+      .put("/profile")
+      .set("x-tenant-id", tenant.id)
+      .send({})
+      .expect(400);
+
+    // Invalid seniority
+    await request(app.getHttpServer())
+      .put("/profile")
+      .set("x-tenant-id", tenant.id)
+      .send({
+        desiredRoles: ["backend"],
+        seniority: "expert", // invalid
+        location: "remote",
+        mustHaveSkills: ["go"]
+      })
+      .expect(400);
+
+    // Empty arrays
+    await request(app.getHttpServer())
+      .put("/profile")
+      .set("x-tenant-id", tenant.id)
+      .send({
+        desiredRoles: [],
+        seniority: "mid",
+        location: "remote",
+        mustHaveSkills: ["go"]
+      })
+      .expect(400);
+  });
+});

--- a/packages/db/prisma/migrations/20260204111031_add_user_profile/migration.sql
+++ b/packages/db/prisma/migrations/20260204111031_add_user_profile/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "UserProfile" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "desiredRoles" TEXT[],
+    "seniority" TEXT NOT NULL,
+    "location" TEXT NOT NULL,
+    "mustHaveSkills" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserProfile_tenantId_key" ON "UserProfile"("tenantId");
+
+-- AddForeignKey
+ALTER TABLE "UserProfile" ADD CONSTRAINT "UserProfile_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Tenant {
   artefacts    AgentArtefact[]
   approvals    Approval[]
   consentLogs  ConsentLog[]
+  userProfile  UserProfile?
 }
 
 model User {
@@ -154,6 +155,19 @@ model ConsentLog {
   action    String
   metadata  Json
   createdAt DateTime @default(now())
+
+  tenant Tenant @relation(fields: [tenantId], references: [id])
+}
+
+model UserProfile {
+  id             String   @id @default(cuid())
+  tenantId       String   @unique
+  desiredRoles   String[]
+  seniority      String
+  location       String
+  mustHaveSkills String[]
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   tenant Tenant @relation(fields: [tenantId], references: [id])
 }


### PR DESCRIPTION
## Summary

- Add **UserProfile** model to store matching preferences per tenant (desiredRoles, seniority, location, mustHaveSkills)
- Add **GET/PUT /profile** endpoints for profile CRUD operations
- Add **GET /matching/jobs/:jobId** endpoint that scores jobs against the stored profile
- Return 404 when job not found, 400 when profile not configured

## New Files

- \pps/api/src/profile/profile.dto.ts\ - DTOs with class-validator
- \pps/api/src/profile/profile.service.ts\ - CRUD operations
- \pps/api/src/profile/profile.controller.ts\ - REST endpoints
- \pps/api/test/profile.e2e-spec.ts\ - 5 e2e tests
- \packages/db/prisma/migrations/20260204111031_add_user_profile/\ - Migration

## Modified Files

- \pps/api/src/matching/matching.service.ts\ - Added \getJobMatch()\ method
- \pps/api/src/matching/matching.controller.ts\ - Added GET endpoint
- \pps/api/test/matching.e2e-spec.ts\ - 4 new tests
- \packages/db/prisma/schema.prisma\ - Added UserProfile model

## Test Plan

- [x] \pnpm typecheck\ - All packages pass
- [x] \pnpm lint\ - No errors
- [x] \pnpm test\ - 29 web + 4 package tests pass
- [x] \pnpm --filter @cv/api test:e2e\ - 20/20 e2e tests pass

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profile management: create, update, and retrieve profiles (desired roles, seniority, location, required skills).
  * Job matching: fetch a match score and basic job info for a specific job based on the tenant's profile.

* **Database**
  * Persistent user profile storage added with tenant-linked profile records.

* **Tests**
  * Comprehensive end-to-end tests covering profile CRUD, validation, and job-matching scenarios (success and error cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->