### PR TITLE
feat: add job search query model and DTOs

### DIFF
--- a/apps/api/src/jobs/dto/job-search-query-create.dto.test.ts
+++ b/apps/api/src/jobs/dto/job-search-query-create.dto.test.ts
@@ -1,0 +1,14 @@
+import "reflect-metadata";
+import { validate } from "class-validator";
+import { JobSearchQueryCreateDto } from "./job-search-query-create.dto";
+
+describe("JobSearchQueryCreateDto validation", () => {
+  it("rejects empty query", async () => {
+    const dto = new JobSearchQueryCreateDto();
+    dto.query = "";
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/jobs/dto/job-search-query-create.dto.ts
+++ b/apps/api/src/jobs/dto/job-search-query-create.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty } from "class-validator";
+import { JobSearchQueryDto } from "./job-search-query.dto";
+
+export class JobSearchQueryCreateDto extends JobSearchQueryDto {
+  @IsNotEmpty()
+  override query!: string;
+}

--- a/apps/api/src/jobs/dto/job-search-query-response.dto.ts
+++ b/apps/api/src/jobs/dto/job-search-query-response.dto.ts
@@ -1,0 +1,16 @@
+import { JobSearchProvider } from "./job-search-query.dto";
+
+export class JobSearchQueryResponseDto {
+  id!: string;
+  tenantId!: string;
+  provider!: JobSearchProvider;
+  query!: string;
+  location!: string | null;
+  seniority!: string | null;
+  keywords!: string[];
+  cadenceSeconds!: number;
+  enabled!: boolean;
+  lastRunAt!: string | null;
+  createdAt!: string;
+  updatedAt!: string;
+}

--- a/apps/api/src/jobs/dto/job-search-query.dto.ts
+++ b/apps/api/src/jobs/dto/job-search-query.dto.ts
@@ -1,0 +1,45 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min
+} from "class-validator";
+
+export const JOB_SEARCH_PROVIDERS = ["serpapi", "jsearch", "adzuna"] as const;
+
+export type JobSearchProvider = (typeof JOB_SEARCH_PROVIDERS)[number];
+
+export class JobSearchQueryDto {
+  @IsIn(JOB_SEARCH_PROVIDERS)
+  provider!: JobSearchProvider;
+
+  @IsString()
+  query!: string;
+
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @IsOptional()
+  @IsString()
+  seniority?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  keywords?: string[];
+
+  @IsOptional()
+  @IsInt()
+  @Min(30)
+  @Max(3600)
+  cadenceSeconds?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/packages/db/prisma/migrations/20260215113748_add_job_search_query_model/migration.sql
+++ b/packages/db/prisma/migrations/20260215113748_add_job_search_query_model/migration.sql
@@ -1,0 +1,21 @@
+﻿-- CreateTable
+CREATE TABLE "JobSearchQuery" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "query" TEXT NOT NULL,
+    "location" TEXT,
+    "seniority" TEXT,
+    "keywords" TEXT[],
+    "cadenceSeconds" INTEGER NOT NULL DEFAULT 120,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "lastRunAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "JobSearchQuery_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "JobSearchQuery" ADD CONSTRAINT "JobSearchQuery_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/packages/db/prisma/migrations/20260215113748_add_job_search_query_model/migration.sql
+++ b/packages/db/prisma/migrations/20260215113748_add_job_search_query_model/migration.sql
@@ -1,4 +1,4 @@
-﻿-- CreateTable
+-- CreateTable
 CREATE TABLE "JobSearchQuery" (
     "id" TEXT NOT NULL,
     "tenantId" TEXT NOT NULL,

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Tenant {
   approvals    Approval[]
   consentLogs  ConsentLog[]
   userProfile  UserProfile?
+  jobSearchQueries JobSearchQuery[]
 }
 
 enum AuthProvider {
@@ -174,6 +175,23 @@ model UserProfile {
   seniority      String
   location       String
   mustHaveSkills String[]
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [id])
+}
+
+model JobSearchQuery {
+  id             String   @id @default(cuid())
+  tenantId       String
+  provider       String
+  query          String
+  location       String?
+  seniority      String?
+  keywords       String[]
+  cadenceSeconds Int      @default(120)
+  enabled        Boolean  @default(true)
+  lastRunAt      DateTime?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
- add JobSearchQuery Prisma model and tenant relation
- add jobs DTOs for search query create/request/response
- add DTO validation test for empty query
- add migration SQL for JobSearchQuery table + FK

## Verification
- pnpm --filter @cv/api test -- job-search-query-create.dto.test.ts
- pnpm --filter @cv/api test
- pnpm --filter @cv/api typecheck
- pnpm test

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added job search query management allowing users to create and store job search configurations across multiple providers with parameters (query, location, seniority, keywords), scheduling interval, enable/disable, and a standardized response format for query records.
* **Tests**
  * Added validation tests to ensure job search query creation requires a non-empty query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->