### PR TITLE
feat: add real-time search poller

### DIFF
--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -4,10 +4,14 @@ import {
   createIngestionQueue,
   createIngestionWorker,
   processIngestionJob,
-  type IngestionJobData
+  processSearchPollJob,
+  scheduleSearchQueriesFromDb,
+  type IngestionJobData,
+  createSearchWorker
 } from "./queue";
 
-let worker: Worker | undefined;
+let ingestionWorker: Worker | undefined;
+let searchWorker: Worker | undefined;
 
 /**
  * Graceful shutdown handling.
@@ -21,9 +25,14 @@ async function shutdown(signal: string): Promise<void> {
   console.log(`\n[Worker] Received ${signal}, shutting down gracefully...`);
 
   try {
-    if (worker) {
-      await worker.close();
-      console.log("[Worker] BullMQ worker closed");
+    if (ingestionWorker) {
+      await ingestionWorker.close();
+      console.log("[Worker] Ingestion worker closed");
+    }
+
+    if (searchWorker) {
+      await searchWorker.close();
+      console.log("[Worker] Search poll worker closed");
     }
   } catch (err) {
     console.error("[Worker] Error closing worker:", err);
@@ -108,22 +117,38 @@ async function main(): Promise<void> {
 
   // Schedule repeatable jobs for all sources
   await scheduleRepeatableJobs();
+  await scheduleSearchQueriesFromDb();
 
   // Create and start the worker
-  worker = createIngestionWorker(processIngestionJob);
+  ingestionWorker = createIngestionWorker(processIngestionJob);
+  searchWorker = createSearchWorker(processSearchPollJob);
 
-  worker.on("completed", (job, result) => {
+  ingestionWorker.on("completed", (job, result) => {
     console.log(
       `[Worker] Job ${job.id} completed: ${result.processedCount} jobs processed`
     );
   });
 
-  worker.on("failed", (job, error) => {
+  ingestionWorker.on("failed", (job, error) => {
     console.error(`[Worker] Job ${job?.id} failed:`, error.message);
   });
 
-  worker.on("error", (error) => {
+  ingestionWorker.on("error", (error) => {
     console.error("[Worker] Worker error:", error);
+  });
+
+  searchWorker.on("completed", (job, result) => {
+    console.log(
+      `[SearchPoll] Job ${job.id} completed: ${result.processedCount}/${result.fetchedCount}`
+    );
+  });
+
+  searchWorker.on("failed", (job, error) => {
+    console.error(`[SearchPoll] Job ${job?.id} failed:`, error.message);
+  });
+
+  searchWorker.on("error", (error) => {
+    console.error("[SearchPoll] Worker error:", error);
   });
 
   console.log("[Worker] Worker started and listening for jobs...");

--- a/apps/worker/src/queue/index.ts
+++ b/apps/worker/src/queue/index.ts
@@ -1,3 +1,4 @@
 export * from "./connection";
 export * from "./ingestion.queue";
 export * from "./ingestion.processor";
+export * from "./search-queue";

--- a/apps/worker/src/queue/search-queue.ts
+++ b/apps/worker/src/queue/search-queue.ts
@@ -1,0 +1,254 @@
+import crypto from "node:crypto";
+import { Job, Queue, Worker } from "bullmq";
+import { prisma } from "@cv/db";
+import { createRedisConnection } from "./connection";
+import {
+  JSearchAdapter,
+  SerpApiAdapter,
+  type JobSourceAdapter,
+  type SourceConfig,
+  type NormalizedJob
+} from "../sources";
+
+export const SEARCH_QUEUE_NAME = "job-search-poller";
+
+export interface SearchPollJobData {
+  queryId: string;
+  tenantId: string;
+  provider: string;
+}
+
+export interface SearchPollJobResult {
+  fetchedCount: number;
+  processedCount: number;
+  errors?: string[];
+  completedAt: string;
+}
+
+export interface SearchPollQuery {
+  id: string;
+  tenantId: string;
+  provider: string;
+  cadenceSeconds: number;
+  enabled: boolean;
+}
+
+const searchAdapters: Record<string, JobSourceAdapter> = {
+  jsearch: new JSearchAdapter(),
+  serpapi: new SerpApiAdapter()
+};
+
+export function createSearchQueue(): Queue<SearchPollJobData, SearchPollJobResult> {
+  return new Queue<SearchPollJobData, SearchPollJobResult>(SEARCH_QUEUE_NAME, {
+    connection: createRedisConnection(),
+    defaultJobOptions: {
+      attempts: 2,
+      removeOnComplete: { age: 24 * 3600, count: 1000 },
+      removeOnFail: { age: 7 * 24 * 3600 }
+    }
+  });
+}
+
+export function createSearchWorker(
+  processor: (job: Job<SearchPollJobData>) => Promise<SearchPollJobResult>
+): Worker<SearchPollJobData, SearchPollJobResult> {
+  return new Worker<SearchPollJobData, SearchPollJobResult>(SEARCH_QUEUE_NAME, processor, {
+    connection: createRedisConnection(),
+    concurrency: 3
+  });
+}
+
+export async function scheduleSearchQueries(
+  queue: Pick<Queue<SearchPollJobData, SearchPollJobResult>, "add">,
+  queries: SearchPollQuery[]
+): Promise<void> {
+  for (const query of queries) {
+    if (!query.enabled) continue;
+
+    await queue.add(
+      `poll-${query.id}`,
+      {
+        queryId: query.id,
+        tenantId: query.tenantId,
+        provider: query.provider
+      },
+      {
+        repeat: { every: query.cadenceSeconds * 1000 },
+        jobId: `search-repeat-${query.id}`
+      }
+    );
+  }
+}
+
+export async function scheduleSearchQueriesFromDb(): Promise<void> {
+  const queries = await prisma.jobSearchQuery.findMany({
+    where: { enabled: true },
+    select: {
+      id: true,
+      tenantId: true,
+      provider: true,
+      cadenceSeconds: true,
+      enabled: true
+    }
+  });
+
+  const queue = createSearchQueue();
+  try {
+    await scheduleSearchQueries(queue, queries);
+  } finally {
+    await queue.close();
+  }
+}
+
+function hashContent(title: string, description: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${title}::${description}`)
+    .digest("hex");
+}
+
+async function ensureJobSourceForQuery(
+  tenantId: string,
+  queryId: string,
+  provider: string
+): Promise<string> {
+  const sourceName = `realtime-query-${queryId}`;
+
+  const existing = await prisma.jobSource.findFirst({
+    where: {
+      tenantId,
+      type: provider,
+      name: sourceName
+    }
+  });
+
+  if (existing) return existing.id;
+
+  const created = await prisma.jobSource.create({
+    data: {
+      tenantId,
+      type: provider,
+      name: sourceName,
+      config: { queryId }
+    }
+  });
+
+  return created.id;
+}
+
+async function upsertJob(
+  tenantId: string,
+  jobSourceId: string,
+  job: NormalizedJob
+): Promise<void> {
+  const contentHash = hashContent(job.title, job.description);
+
+  await prisma.job.upsert({
+    where: {
+      jobSourceId_externalId: {
+        jobSourceId,
+        externalId: job.externalId
+      }
+    },
+    create: {
+      tenantId,
+      jobSourceId,
+      externalId: job.externalId,
+      title: job.title,
+      description: job.description,
+      location: job.location,
+      url: job.url,
+      postedAt: job.postedAt,
+      contentHash
+    },
+    update: {
+      title: job.title,
+      description: job.description,
+      location: job.location,
+      url: job.url,
+      postedAt: job.postedAt,
+      contentHash,
+      updatedAt: new Date()
+    }
+  });
+}
+
+export async function processSearchPollJob(
+  job: Job<SearchPollJobData>
+): Promise<SearchPollJobResult> {
+  const { queryId, tenantId, provider } = job.data;
+  const adapter = searchAdapters[provider];
+
+  if (!adapter) {
+    return {
+      fetchedCount: 0,
+      processedCount: 0,
+      errors: [`Unknown search provider: ${provider}`],
+      completedAt: new Date().toISOString()
+    };
+  }
+
+  const searchQuery = await prisma.jobSearchQuery.findFirst({
+    where: { id: queryId, tenantId, enabled: true }
+  });
+
+  if (!searchQuery) {
+    return {
+      fetchedCount: 0,
+      processedCount: 0,
+      errors: ["Search query not found or disabled"],
+      completedAt: new Date().toISOString()
+    };
+  }
+
+  const sourceApiKey =
+    provider === "jsearch"
+      ? process.env.JSEARCH_API_KEY
+      : provider === "serpapi"
+        ? process.env.SERPAPI_API_KEY
+        : undefined;
+
+  const fetchResult = await adapter.fetch({
+    apiKey: sourceApiKey,
+    query: searchQuery.query,
+    location: searchQuery.location ?? undefined,
+    keywords: searchQuery.keywords,
+    limit: 50
+  } as SourceConfig);
+
+  if (fetchResult.errors?.length) {
+    return {
+      fetchedCount: fetchResult.jobs.length,
+      processedCount: 0,
+      errors: fetchResult.errors,
+      completedAt: new Date().toISOString()
+    };
+  }
+
+  const jobSourceId = await ensureJobSourceForQuery(tenantId, queryId, provider);
+
+  let processedCount = 0;
+  const errors: string[] = [];
+  for (const fetchedJob of fetchResult.jobs) {
+    try {
+      await upsertJob(tenantId, jobSourceId, fetchedJob);
+      processedCount++;
+    } catch (error) {
+      errors.push(
+        `Failed to upsert job ${fetchedJob.externalId}: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+    }
+  }
+
+  await prisma.jobSearchQuery.update({
+    where: { id: queryId },
+    data: { lastRunAt: new Date() }
+  });
+
+  return {
+    fetchedCount: fetchResult.jobs.length,
+    processedCount,
+    errors: errors.length > 0 ? errors : undefined,
+    completedAt: new Date().toISOString()
+  };
+}

--- a/apps/worker/src/queue/search-queue.ts
+++ b/apps/worker/src/queue/search-queue.ts
@@ -114,26 +114,26 @@ async function ensureJobSourceForQuery(
 ): Promise<string> {
   const sourceName = `realtime-query-${queryId}`;
 
-  const existing = await prisma.jobSource.findFirst({
+  const source = await prisma.jobSource.upsert({
     where: {
-      tenantId,
-      type: provider,
-      name: sourceName
-    }
-  });
-
-  if (existing) return existing.id;
-
-  const created = await prisma.jobSource.create({
-    data: {
+      tenantId_type_name: {
+        tenantId,
+        type: provider,
+        name: sourceName
+      }
+    },
+    create: {
       tenantId,
       type: provider,
       name: sourceName,
       config: { queryId }
+    },
+    update: {
+      config: { queryId }
     }
   });
 
-  return created.id;
+  return source.id;
 }
 
 async function upsertJob(

--- a/apps/worker/src/sources/index.ts
+++ b/apps/worker/src/sources/index.ts
@@ -2,3 +2,5 @@ export * from "./types";
 export { GreenhouseAdapter } from "./greenhouse-adapter";
 export { RemoteOKAdapter } from "./remoteok-adapter";
 export { RemotiveAdapter } from "./remotive-adapter";
+export { JSearchAdapter } from "./jsearch-adapter";
+export { SerpApiAdapter } from "./serpapi-adapter";

--- a/apps/worker/src/sources/jsearch-adapter.ts
+++ b/apps/worker/src/sources/jsearch-adapter.ts
@@ -1,0 +1,88 @@
+import type {
+  JobSourceAdapter,
+  SourceConfig,
+  FetchResult,
+  NormalizedJob
+} from "./types";
+
+interface JSearchJob {
+  job_id?: string;
+  job_title?: string;
+  job_description?: string;
+  job_city?: string;
+  job_country?: string;
+  job_apply_link?: string;
+  employer_name?: string;
+  job_posted_at_datetime_utc?: string;
+}
+
+interface JSearchResponse {
+  data?: JSearchJob[];
+}
+
+export class JSearchAdapter implements JobSourceAdapter {
+  readonly type = "jsearch" as const;
+  readonly name = "JSearch";
+
+  validateConfig(config: SourceConfig): true | string {
+    if (!config.apiKey) return "apiKey is required for JSearch source";
+    if (!config.query) return "query is required for JSearch source";
+    return true;
+  }
+
+  async fetch(config: SourceConfig): Promise<FetchResult> {
+    const validation = this.validateConfig(config);
+    if (validation !== true) {
+      return { jobs: [], errors: [validation] };
+    }
+
+    const params = new URLSearchParams({
+      query: config.query!,
+      page: "1",
+      num_pages: "1"
+    });
+
+    const response = await fetch(`https://jsearch.p.rapidapi.com/search?${params.toString()}`, {
+      headers: {
+        "X-RapidAPI-Key": config.apiKey!,
+        "X-RapidAPI-Host": "jsearch.p.rapidapi.com"
+      }
+    });
+
+    if (!response.ok) {
+      return {
+        jobs: [],
+        errors: [`JSearch error (${response.status})`]
+      };
+    }
+
+    const payload = (await response.json()) as JSearchResponse;
+    const jobs = (payload.data ?? []).map(this.normalizeJob).filter(Boolean) as NormalizedJob[];
+
+    return {
+      jobs: config.limit ? jobs.slice(0, config.limit) : jobs,
+      totalCount: jobs.length
+    };
+  }
+
+  private normalizeJob(job: JSearchJob): NormalizedJob | null {
+    if (!job.job_id || !job.job_title || !job.job_apply_link) {
+      return null;
+    }
+
+    const location = [job.job_city, job.job_country].filter(Boolean).join(", ") || undefined;
+
+    return {
+      externalId: `js-${job.job_id}`,
+      title: job.job_title,
+      description: job.job_description ?? "",
+      location,
+      url: job.job_apply_link,
+      company: job.employer_name,
+      postedAt: job.job_posted_at_datetime_utc
+        ? new Date(job.job_posted_at_datetime_utc)
+        : undefined,
+      tags: ["jsearch"]
+    };
+  }
+}

--- a/apps/worker/src/sources/serpapi-adapter.ts
+++ b/apps/worker/src/sources/serpapi-adapter.ts
@@ -1,0 +1,92 @@
+import type {
+  JobSourceAdapter,
+  SourceConfig,
+  FetchResult,
+  NormalizedJob
+} from "./types";
+
+interface SerpApiJob {
+  job_id?: string;
+  title?: string;
+  description?: string;
+  location?: string;
+  thumbnail?: string;
+  detected_extensions?: {
+    posted_at?: string;
+  };
+  related_links?: Array<{ link?: string }>;
+  apply_options?: Array<{ link?: string }>;
+}
+
+interface SerpApiResponse {
+  jobs_results?: SerpApiJob[];
+}
+
+export class SerpApiAdapter implements JobSourceAdapter {
+  readonly type = "serpapi" as const;
+  readonly name = "SerpAPI";
+
+  validateConfig(config: SourceConfig): true | string {
+    if (!config.apiKey) return "apiKey is required for SerpAPI source";
+    if (!config.query) return "query is required for SerpAPI source";
+    return true;
+  }
+
+  async fetch(config: SourceConfig): Promise<FetchResult> {
+    const validation = this.validateConfig(config);
+    if (validation !== true) {
+      return { jobs: [], errors: [validation] };
+    }
+
+    const params = new URLSearchParams({
+      engine: "google_jobs",
+      q: config.query!,
+      hl: "en",
+      api_key: config.apiKey!
+    });
+
+    if (config.location) {
+      params.set("location", config.location);
+    }
+
+    const response = await fetch(`https://serpapi.com/search.json?${params.toString()}`);
+
+    if (!response.ok) {
+      return {
+        jobs: [],
+        errors: [`SerpAPI error (${response.status})`]
+      };
+    }
+
+    const payload = (await response.json()) as SerpApiResponse;
+    const jobs = (payload.jobs_results ?? []).map(this.normalizeJob).filter(Boolean) as NormalizedJob[];
+
+    return {
+      jobs: config.limit ? jobs.slice(0, config.limit) : jobs,
+      totalCount: jobs.length
+    };
+  }
+
+  private normalizeJob(job: SerpApiJob): NormalizedJob | null {
+    const externalId = job.job_id;
+    const title = job.title;
+    if (!externalId || !title) return null;
+
+    const url =
+      job.apply_options?.[0]?.link ||
+      job.related_links?.[0]?.link ||
+      "https://www.google.com/search?ibp=htl;jobs";
+
+    return {
+      externalId: `serp-${externalId}`,
+      title,
+      description: job.description ?? "",
+      location: job.location,
+      url,
+      postedAt: job.detected_extensions?.posted_at
+        ? new Date(job.detected_extensions.posted_at)
+        : undefined,
+      tags: ["serpapi"]
+    };
+  }
+}

--- a/apps/worker/src/sources/serpapi-adapter.ts
+++ b/apps/worker/src/sources/serpapi-adapter.ts
@@ -22,6 +22,41 @@ interface SerpApiResponse {
   jobs_results?: SerpApiJob[];
 }
 
+function parseRelativeTime(value: string): Date | undefined {
+  const trimmed = value.trim().toLowerCase();
+  const match = trimmed.match(/^(\d+)\s+(minute|minutes|hour|hours|day|days|week|weeks)\s+ago$/);
+  if (!match) {
+    return undefined;
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2];
+
+  const unitMs =
+    unit.startsWith("minute")
+      ? 60_000
+      : unit.startsWith("hour")
+        ? 3_600_000
+        : unit.startsWith("day")
+          ? 86_400_000
+          : 604_800_000;
+
+  return new Date(Date.now() - amount * unitMs);
+}
+
+function parsePostedAt(value?: string): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const absolute = new Date(value);
+  if (!Number.isNaN(absolute.getTime())) {
+    return absolute;
+  }
+
+  return parseRelativeTime(value);
+}
+
 export class SerpApiAdapter implements JobSourceAdapter {
   readonly type = "serpapi" as const;
   readonly name = "SerpAPI";
@@ -83,9 +118,7 @@ export class SerpApiAdapter implements JobSourceAdapter {
       description: job.description ?? "",
       location: job.location,
       url,
-      postedAt: job.detected_extensions?.posted_at
-        ? new Date(job.detected_extensions.posted_at)
-        : undefined,
+      postedAt: parsePostedAt(job.detected_extensions?.posted_at),
       tags: ["serpapi"]
     };
   }

--- a/apps/worker/src/sources/types.ts
+++ b/apps/worker/src/sources/types.ts
@@ -22,6 +22,7 @@ export type SourceType =
   | "lever"
   | "remoteok"
   | "remotive"
+  | "serpapi"
   | "jsearch"
   | "adzuna"
   | "manual";
@@ -31,6 +32,8 @@ export type SourceType =
  * Different source types use different config fields.
  */
 export interface SourceConfig {
+  /** Search query for live provider APIs */
+  query?: string;
   /** Board URL for Greenhouse/Lever sources */
   boardUrl?: string;
   /** Company name for identification */

--- a/apps/worker/test/search-poller.test.ts
+++ b/apps/worker/test/search-poller.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { scheduleSearchQueries } from "../src/queue/search-queue";
+
+describe("scheduleSearchQueries", () => {
+  it("schedules queries every cadenceSeconds", async () => {
+    const add = vi.fn().mockResolvedValue(undefined);
+
+    await scheduleSearchQueries(
+      {
+        add
+      },
+      [
+        {
+          id: "q-1",
+          tenantId: "tenant-1",
+          provider: "jsearch",
+          cadenceSeconds: 120,
+          enabled: true
+        },
+        {
+          id: "q-2",
+          tenantId: "tenant-1",
+          provider: "serpapi",
+          cadenceSeconds: 60,
+          enabled: true
+        }
+      ]
+    );
+
+    expect(add).toHaveBeenCalledWith(
+      "poll-q-1",
+      { queryId: "q-1", tenantId: "tenant-1", provider: "jsearch" },
+      {
+        repeat: { every: 120000 },
+        jobId: "search-repeat-q-1"
+      }
+    );
+
+    expect(add).toHaveBeenCalledWith(
+      "poll-q-2",
+      { queryId: "q-2", tenantId: "tenant-1", provider: "serpapi" },
+      {
+        repeat: { every: 60000 },
+        jobId: "search-repeat-q-2"
+      }
+    );
+  });
+});

--- a/apps/worker/test/sources.test.ts
+++ b/apps/worker/test/sources.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   isJuniorRole,
   isDeveloperRole,
@@ -8,6 +8,12 @@ import {
 import { GreenhouseAdapter } from "../src/sources/greenhouse-adapter";
 import { RemoteOKAdapter } from "../src/sources/remoteok-adapter";
 import { RemotiveAdapter } from "../src/sources/remotive-adapter";
+import { JSearchAdapter } from "../src/sources/jsearch-adapter";
+import { SerpApiAdapter } from "../src/sources/serpapi-adapter";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("Source Types", () => {
   describe("isJuniorRole", () => {
@@ -127,6 +133,85 @@ describe("Adapters", () => {
 
     it("validates config always passes", () => {
       expect(adapter.validateConfig({})).toBe(true);
+    });
+  });
+
+  describe("JSearchAdapter", () => {
+    const adapter = new JSearchAdapter();
+
+    it("has correct type and name", () => {
+      expect(adapter.type).toBe("jsearch");
+      expect(adapter.name).toBe("JSearch");
+    });
+
+    it("requires apiKey and query", () => {
+      expect(adapter.validateConfig({})).toBe("apiKey is required for JSearch source");
+      expect(adapter.validateConfig({ apiKey: "key" })).toBe("query is required for JSearch source");
+      expect(adapter.validateConfig({ apiKey: "key", query: "junior developer" })).toBe(true);
+    });
+
+    it("normalizes fetched jobs", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            data: [
+              {
+                job_id: "abc",
+                job_title: "Junior Developer",
+                job_description: "Build things",
+                job_city: "Tel Aviv",
+                job_country: "IL",
+                job_apply_link: "https://example.com/job",
+                employer_name: "Acme"
+              }
+            ]
+          })
+        })
+      );
+
+      const result = await adapter.fetch({ apiKey: "key", query: "junior developer" });
+
+      expect(result.jobs).toHaveLength(1);
+      expect(result.jobs[0].externalId).toBe("js-abc");
+      expect(result.jobs[0].title).toBe("Junior Developer");
+    });
+  });
+
+  describe("SerpApiAdapter", () => {
+    const adapter = new SerpApiAdapter();
+
+    it("requires apiKey and query", () => {
+      expect(adapter.validateConfig({})).toBe("apiKey is required for SerpAPI source");
+      expect(adapter.validateConfig({ apiKey: "key" })).toBe("query is required for SerpAPI source");
+      expect(adapter.validateConfig({ apiKey: "key", query: "junior developer" })).toBe(true);
+    });
+
+    it("normalizes fetched jobs", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            jobs_results: [
+              {
+                job_id: "xyz",
+                title: "Junior Software Engineer",
+                description: "Entry role",
+                location: "Israel",
+                apply_options: [{ link: "https://example.com/serp-job" }]
+              }
+            ]
+          })
+        })
+      );
+
+      const result = await adapter.fetch({ apiKey: "key", query: "junior engineer" });
+
+      expect(result.jobs).toHaveLength(1);
+      expect(result.jobs[0].externalId).toBe("serp-xyz");
+      expect(result.jobs[0].url).toBe("https://example.com/serp-job");
     });
   });
 });

--- a/apps/worker/test/sources.test.ts
+++ b/apps/worker/test/sources.test.ts
@@ -213,5 +213,58 @@ describe("Adapters", () => {
       expect(result.jobs[0].externalId).toBe("serp-xyz");
       expect(result.jobs[0].url).toBe("https://example.com/serp-job");
     });
+
+    it("parses relative posted_at timestamps", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-02-15T12:00:00.000Z"));
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            jobs_results: [
+              {
+                job_id: "rel-1",
+                title: "Junior Backend Developer",
+                apply_options: [{ link: "https://example.com/relative" }],
+                detected_extensions: { posted_at: "2 days ago" }
+              }
+            ]
+          })
+        })
+      );
+
+      const result = await adapter.fetch({ apiKey: "key", query: "junior backend" });
+
+      expect(result.jobs).toHaveLength(1);
+      expect(result.jobs[0].postedAt?.toISOString()).toBe("2026-02-13T12:00:00.000Z");
+
+      vi.useRealTimers();
+    });
+
+    it("falls back to undefined for unparseable posted_at", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            jobs_results: [
+              {
+                job_id: "bad-1",
+                title: "Junior Frontend Engineer",
+                apply_options: [{ link: "https://example.com/bad-date" }],
+                detected_extensions: { posted_at: "sometime recently" }
+              }
+            ]
+          })
+        })
+      );
+
+      const result = await adapter.fetch({ apiKey: "key", query: "junior frontend" });
+
+      expect(result.jobs).toHaveLength(1);
+      expect(result.jobs[0].postedAt).toBeUndefined();
+    });
   });
 });

--- a/packages/db/prisma/migrations/20260215122000_add_job_source_tenant_type_name_unique/migration.sql
+++ b/packages/db/prisma/migrations/20260215122000_add_job_source_tenant_type_name_unique/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "JobSource_tenantId_type_name_key" ON "JobSource"("tenantId", "type", "name");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -92,6 +92,8 @@ model JobSource {
 
   tenant Tenant @relation(fields: [tenantId], references: [id])
   jobs   Job[]
+
+  @@unique([tenantId, type, name])
 }
 
 model Job {


### PR DESCRIPTION
## Summary
- add search poll queue and worker processor for tenant saved queries
- schedule repeatable poll jobs from JobSearchQuery.cadenceSeconds
- add provider adapters for JSearch and SerpAPI
- wire search poll scheduler/worker into worker bootstrap
- add tests for poll cadence scheduling and provider adapters

## Verification
- pnpm --filter @cv/worker test -- search-poller.test.ts
- pnpm --filter @cv/worker test -- sources.test.ts
- pnpm --filter @cv/worker test
- pnpm --filter @cv/worker typecheck

Refs #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time search polling: The system now continuously monitors searches through automated polling on scheduled intervals.
  * Multiple job sources: Integrated JSearch and SerpAPI adapters to expand job listing sources and data providers.
  * Automated query scheduling: Search queries are loaded from the database and automatically scheduled on startup.

* **Tests**
  * Added test coverage for search polling and job source adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->